### PR TITLE
Optionally store a previously initialized SmartRedis client

### DIFF
--- a/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_ocean_model_nuopc.F90
@@ -61,7 +61,7 @@ use MOM_surface_forcing_nuopc, only : surface_forcing_init, convert_IOB_to_fluxe
 use MOM_surface_forcing_nuopc, only : convert_IOB_to_forces, ice_ocn_bnd_type_chksum
 use MOM_surface_forcing_nuopc, only : ice_ocean_boundary_type, surface_forcing_CS
 use MOM_surface_forcing_nuopc, only : forcing_save_restart
-
+use nuopc_shr_methods,         only : sr_client
 #include <MOM_memory.h>
 
 #ifdef _USE_GENERIC_TRACER
@@ -276,7 +276,7 @@ subroutine ocean_model_init(Ocean_sfc, OS, Time_init, Time_in, gas_fields_ocn, i
   call initialize_MOM(OS%Time, Time_init, param_file, OS%dirs, OS%MOM_CSp, &
                       OS%restart_CSp, Time_in, offline_tracer_mode=OS%offline_tracer_mode, &
                       input_restart_file=input_restart_file, &
-                      diag_ptr=OS%diag, count_calls=.true.)
+                      diag_ptr=OS%diag, count_calls=.true., client_in=sr_client)
   call get_MOM_state_elements(OS%MOM_CSp, G=OS%grid, GV=OS%GV, US=OS%US, C_p=OS%C_p, &
                               C_p_scaled=OS%fluxes%C_p, use_temp=use_temperature)
 

--- a/config_src/external/smartredis/client.F90
+++ b/config_src/external/smartredis/client.F90
@@ -9,6 +9,8 @@ implicit none; private
 type, public :: client_type
   private
 
+  logical :: is_initialized = .false. !< True if client is initialized
+
   contains
 
   ! Public procedures
@@ -21,6 +23,8 @@ type, public :: client_type
 
   !> Initializes a new instance of the SmartRedis client
   procedure :: initialize
+  !> Check if a SmartRedis client has been initialized
+  procedure :: isinitialized
   !> Destructs a new instance of the SmartRedis client
   procedure :: destructor
   !> Check the database for the existence of a specific model
@@ -101,6 +105,11 @@ subroutine initialize( this, cluster )
   logical, optional :: cluster !< If true, client uses a database cluster (Default: .false.)
 
 end subroutine initialize
+
+logical function isinitialized(this)
+  class(client_type) :: this
+  isinitialized = this%is_initialized
+end function isinitialized
 
 !> A destructor for the SmartRedis client
 subroutine destructor( this )

--- a/src/framework/MOM_smartredis.F90
+++ b/src/framework/MOM_smartredis.F90
@@ -9,12 +9,16 @@ use smartredis_client,    only : client_type
 implicit none; private
 
 public :: client_type
+public :: smartredis_init
 
 contains
 
-subroutine smartredis_init(param_file, client)
+subroutine smartredis_init(param_file, client, client_in)
   type(param_file_type), intent(in   ) :: param_file !< Parameter file structure
-  type(client_type),     intent(inout) :: client     !< Client used to communicate with the SmartRedis database
+  type(client_type),     intent(inout) :: client     !< Client used to communicate with the RedisAI
+                                                     !! database to be stored in the MOM control structure
+  type(client_type), optional, intent(in   ) :: client_in !< If present, use a previously initialized
+                                                          !! SmartRedis client
 
   character(len=40) :: mdl = "MOM_SMARTREDIS"
   logical :: use_smartredis
@@ -22,17 +26,29 @@ subroutine smartredis_init(param_file, client)
   integer :: id_client_init
 
   call get_param(param_file, mdl, "USE_SMARTREDIS",  use_smartredis, &
-  		 "If true, initialize the client used to communcicate "//&
-		 "with the SmartRedis database", default=.false.)
+                 "If true, use the data client to connect"//&
+                 "with the SmartRedis database", default=.false.)
 
-  if (use_smartredis) then
+  if (present(client_in)) then ! The driver (e.g. the NUOPC cap) has already initialized the client
+
+    client = client_in
+
+    if (.not. client%isinitialized() .and. use_smartredis) then
+      call MOM_error(FATAL, &
+      "If using a SmartRedis client not initialized within MOM, client%initialize must have already been invoked."//&
+      " Check that the client has been initialized in the driver before the call to initialize_MOM")
+    endif
+
+  elseif (use_smartredis) then ! The client will be initialized within MOM
+
     call get_param(param_file, mdl, "USE_SMARTREDIS_CLUSTER",  use_smartredis_cluster, &
-    		   "If true, the SmartRedis database is distributed over multiple nodes.",&
-		   default=.true.)
+                   "If true, the SmartRedis database is distributed over multiple nodes.",&
+                   default=.true.)
     id_client_init = cpu_clock_id('(SMARTREDIS client init)', grain=CLOCK_ROUTINE)
     call cpu_clock_begin(id_client_init)
     call client%initialize(use_smartredis_cluster)
     call cpu_clock_end(id_client_init)
+
   endif
 
 end subroutine smartredis_init


### PR DESCRIPTION
Adds an alternate way to use a SmartRedis client within MOM6. Before, MOM6 always assumed that it would be responsible for initializing and storing the SmartRedis client within the main MOM control structure. Now, if a previously initialized client is passed into `initialize_MOM` through an optional arugment, a copy of that client is stored. One additional check has been added to ensure that if the user specified `USE_SMARTREDIS = True` that this copy of the client is also initialized.

Additionally, the NUOPC cap has been modified to import the instance of the SmartRedis client stored within `nuopc_shr_methods` and to pass that client into `initialize_MOM`.